### PR TITLE
Preg split behavior empty strings

### DIFF
--- a/o3po/admin/class-o3po-admin.php
+++ b/o3po/admin/class-o3po-admin.php
@@ -209,7 +209,7 @@ class O3PO_Admin {
                 'corresponding_author_email' => array('callable' => array('O3PO_PublicationType', 'get_corresponding_author_email'), 'field_type' => 'string'),
             ];
             if(isset( $_GET['meta_data_field_list'] ))
-                $meta_data_field_list = preg_split('/\s*,\s*/', $_GET['meta_data_field_list']);
+                $meta_data_field_list = preg_split('/\s*,\s*/', $_GET['meta_data_field_list'], -1, PREG_SPLIT_NO_EMPTY);
             else
                 $meta_data_field_list = ['formated_authors', 'number_authors', 'title', 'corresponding_author_email'];
 

--- a/o3po/includes/class-o3po-ads.php
+++ b/o3po/includes/class-o3po-ads.php
@@ -107,7 +107,7 @@ class O3PO_Ads {
                 $authors = array();
                 foreach($doc->author as $author)
                 {
-                    $names = preg_split('#\s*,\s*#', $author);
+                    $names = preg_split('#\s*,\s*#', $author, -1, PREG_SPLIT_NO_EMPTY);
                     $authors[] = new O3PO_Author(!empty($names[1]) ? $names[1] : '', !empty($names[0]) ? $names[0] : '');
                 }
 

--- a/o3po/includes/class-o3po-arxiv.php
+++ b/o3po/includes/class-o3po-arxiv.php
@@ -55,7 +55,7 @@ class O3PO_Arxiv {
             if(!empty($arxiv_author_links))
             {
                 foreach ($arxiv_author_links as $x => $arxiv_author_link) {
-                    $arxiv_author_names = preg_split('/\s+(?=\S+$)/', $arxiv_author_link->nodeValue);
+                    $arxiv_author_names = preg_split('/\s+(?=\S+$)/', $arxiv_author_link->nodeValue, -1, PREG_SPLIT_NO_EMPTY);
                     if ( !empty($arxiv_author_names[0]) )
                         $author_given_names[$x] = $arxiv_author_names[0];
                     if ( !empty($arxiv_author_names[1]) )

--- a/o3po/includes/class-o3po-author.php
+++ b/o3po/includes/class-o3po-author.php
@@ -35,7 +35,7 @@ class O3PO_Author {
         if(is_array($affiliations))
             $this->affiliations = $affiliations;
         else
-            $this->affiliations = preg_split('/\s*,\s*/', (string)$affiliations);
+            $this->affiliations = preg_split('/\s*,\s*/', (string)$affiliations, -1, PREG_SPLIT_NO_EMPTY);
     }
 
     public function get( $field ) {

--- a/o3po/includes/class-o3po-latex.php
+++ b/o3po/includes/class-o3po-latex.php
@@ -118,7 +118,7 @@ class O3PO_Latex extends O3PO_Latex_Dictionary_Provider
     static public function parse_bbl( $bbl ) {
 
         $citations = array();
-        $bbls = preg_split('/(% \$ biblatex auxiliary file \$|\\\\begin{thebibliography}|\\\\begin{references})/', $bbl, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $bbls = preg_split('/(% \$ biblatex auxiliary file \$|\\\\begin{thebibliography}|\\\\begin{references})/', $bbl, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         foreach($bbls as $individual_bbl)
             $citations = array_merge($citations, static::parse_single_bbl($individual_bbl));
 
@@ -155,7 +155,7 @@ class O3PO_Latex extends O3PO_Latex_Dictionary_Provider
                 '(?<!\\\\)%.*' => '', //remove all comments
                                        );
 
-            $entries = preg_split('/\\\\entry/', $bbl);
+            $entries = preg_split('/\\\\entry/', $bbl, -1, PREG_SPLIT_NO_EMPTY);
             foreach($entries as $n => $entry) {
                 if(strpos($entry, '\\endentry' ) === false ) continue;
 
@@ -167,7 +167,7 @@ class O3PO_Latex extends O3PO_Latex_Dictionary_Provider
                 $citations[$n]['ref'] = $n;
 
                 preg_match('#\\\\name\{[^}]*\}\{[^}]*\}\{\}(?=\{((?:[^{}]++|\{(?1)\})*)\})#', $entry, $name);//matches balanced parenthesis (Note the use of (?1) here!) to test changes go here https://regex101.com/r/bVHadc/1
-                foreach(preg_split('/{{hash=/', $name[1]) as $i => $author_bbl) {
+                foreach(preg_split('/{{hash=/', $name[1], -1, PREG_SPLIT_NO_EMPTY) as $i => $author_bbl) {
                     if($i === 0) continue;
                     preg_match('#family={(.*?)},#', $author_bbl, $family );
                     preg_match('#familyi={(.*?)},#', $author_bbl, $familyi );
@@ -339,10 +339,7 @@ class O3PO_Latex extends O3PO_Latex_Dictionary_Provider
                 $style = 'author-year';
 
             $bbl = preg_replace('#\\\\(newcommand|providecommand|def)(?:\{| +|)(\\\\[@a-zA-Z]+)(?:\}| +|)(\[[0-9]\]|)(\[[^]]*\]|)(?=\{((?:[^{}]++|\{(?5)\})*)\})#', '', $bbl); //remove all \newcommand and similar (Note the use of (?5) here!) to test changes go here https://regex101.com/r/g7LCUO/1
-
-//		$entries = preg_split('/\\\\bibitem(?=[^a-zA-Z])/', $bbl);
-            $entries = preg_split('/\\\\bibitem\s*(?=[[{])/', $bbl);
-//      $entries = preg_split('#\\\\bibitem\s*(?:(?=\[((?:[^\[\]]++|\[(?1)\])*)\])\s*\[(?1)\]|)\s*(?=\{((?:[^{}]++|\{(?2)\})*)\})\s*{(?2)}#', $bbl);
+            $entries = preg_split('/\\\\bibitem\s*(?=[[{])/', $bbl, -1, PREG_SPLIT_NO_EMPTY);
 
             $citations = array();
 
@@ -723,7 +720,7 @@ class O3PO_Latex extends O3PO_Latex_Dictionary_Provider
     static public function title_to_key_suffix( $text ) {
 
         $text = trim(O3PO_Utility::remove_stopwords($text));
-        $words = preg_split('/( |-|\\$)/', $text);
+        $words = preg_split('/( |-|\\$)/', $text, -1, PREG_SPLIT_NO_EMPTY);
         $key = '';
         if(!empty($words[0]))
             $key .= $words[0];
@@ -1435,7 +1432,7 @@ class O3PO_Latex_Dictionary_Provider
         foreach($refs[1] as $x => $ref)
         {
             $replacement = '[';
-            foreach(preg_split('#\s*,\s*#', $ref) as $bibtex_key) {
+            foreach(preg_split('#\s*,\s*#', $ref, -1, PREG_SPLIT_NO_EMPTY) as $bibtex_key) {
                 $replacement .= '<a onclick="document.getElementById(\'references\').style.display=\'block\';" href="#' . $bibtex_key . '">' . ( isset($bibtex_key_dict[$bibtex_key]) ? $bibtex_key_dict[$bibtex_key] : '?' )  . '</a>,';
             }
             $replacement = rtrim($replacement,',');

--- a/o3po/includes/class-o3po-primary-publication-type.php
+++ b/o3po/includes/class-o3po-primary-publication-type.php
@@ -437,7 +437,7 @@ class O3PO_PrimaryPublicationType extends O3PO_PublicationType {
         /*     // Send a trackback to the arXiv */
         /* if(!empty($eprint) && !$this->environment->is_test_environment()) { */
         /*     $eprint_without_version = preg_replace('#v[0-9]+$#', '', $eprint); */
-        /*     $trackback_result = trackback( $this->get_journal_property('arxiv_url_trackback_prefix') . $eprint_without_version , $title, static::get_trackback_excerpt($post_id), $post_id ); */
+        /*     $trackback_result = trackback( $this->get_journal_property('arxiv_url_trackback_prefix') . $eprint_without_version , $title, $this->get_trackback_excerpt($post_id), $post_id ); */
         /*     $validation_result .= "INFO: A trackback was sent to " . $this->get_journal_property('arxiv_url_trackback_prefix') . $eprint_without_version . " and the response was: " . $trackback_result . ".\n" ; */
         /* } */
 
@@ -520,7 +520,7 @@ class O3PO_PrimaryPublicationType extends O3PO_PublicationType {
         /**
          * Get an excerpt for trackbaks.
          */
-    /* private static function get_trackback_excerpt($post_id) { */
+    /* private function get_trackback_excerpt($post_id) { */
     /*     $post_type = get_post_type($post_id); */
 
     /*     if ( $post_type === $this->get_publication_type_name() ) { */

--- a/o3po/includes/class-o3po-publication-type.php
+++ b/o3po/includes/class-o3po-publication-type.php
@@ -650,7 +650,7 @@ abstract class O3PO_PublicationType {
                 $validation_result .= "WARNING: Affiliations of author " . ($x+1) . " are empty.\n" ;
             else {
                 $last_affiliation_num = 0;
-                foreach(preg_split('/,/', $author_affiliations[$x]) as $affiliation_num) {
+                foreach(preg_split('/\s*,\s*/', $author_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY) as $affiliation_num) {
                     if ($affiliation_num < 1 or $affiliation_num > $number_affiliations )
                         $validation_result .= "ERROR: At least one affiliation number of author " . ($x+1) . " does not correspond to an actual affiliation.\n" ;
                     if( $last_affiliation_num >= $affiliation_num )
@@ -1027,7 +1027,7 @@ abstract class O3PO_PublicationType {
             for ($x = 0; $x < $number_authors; $x++) {
                 if(!empty($author_surnames[$x])) echo '<meta name="citation_author" content="' . esc_attr($author_given_names[$x] . " " . $author_surnames[$x]) . '">'."\n";
                 if ( !empty($author_affiliations) && !empty($author_affiliations[$x]) ) {
-                    foreach(preg_split('/,/', $author_affiliations[$x]) as $affiliation_num) {
+                    foreach(preg_split('/\s*,\s*/', $author_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY) as $affiliation_num) {
                         if ( !empty($affiliations[$affiliation_num-1]) )
                             echo '<meta name="citation_author_institution" content="' . esc_attr($affiliations[$affiliation_num-1]) . '">' . "\n";
                     }
@@ -1240,7 +1240,7 @@ abstract class O3PO_PublicationType {
         if(!empty($this->get_journal_property('crossref_archive_locations')) && $journal === $this->get_journal_property('journal_title'))
         {
             $xml .= '	<archive_locations>' . "\n";
-            foreach(preg_split('#,#', $this->get_journal_property('crossref_archive_locations'))  as $archive_name)
+            foreach(preg_split('/\s*,\s*/', $this->get_journal_property('crossref_archive_locations'))  as $archive_name)
                 $xml .= '	  <archive name="' . esc_attr(trim($archive_name)) . '"></archive>' . "\n";
             $xml .= '	</archive_locations>' . "\n";
         }
@@ -1288,7 +1288,7 @@ abstract class O3PO_PublicationType {
             $xml .= '	    <surname>' . esc_html($author_surnames[$x]) . '</surname>' . "\n";
                 // $xml .= '	    <suffix>{0,1}</suffix>' . "\n";
             if ( !empty($author_affiliations) && !empty($author_affiliations[$x]) ) {
-                foreach(preg_split('/,/', $author_affiliations[$x]) as $affiliation_num) {
+                foreach(preg_split('/\s*,\s*/', $author_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY) as $affiliation_num) {
                     if ( !empty($affiliations[$affiliation_num-1]) )
 				     	$xml .= '	    <affiliation>' . esc_html($affiliations[$affiliation_num-1]) . '</affiliation>' . "\n";
                 }
@@ -1554,7 +1554,7 @@ abstract class O3PO_PublicationType {
             $xml .= '            <given-names>' . esc_html($author_given_names[$x]) . '</given-names>' . "\n";
             $xml .= '          </name>' . "\n";
             if ( !empty($author_affiliations) && !empty($author_affiliations[$x]) ) {
-                foreach(preg_split('/,/', $author_affiliations[$x]) as $affiliation_num) {
+                foreach(preg_split('/\s*,\s*/', $author_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY) as $affiliation_num) {
                     $xml .= '          <xref ref-type="aff" rid="aff-' . $affiliation_num . '"/>' . "\n";
                 }
             }
@@ -1752,7 +1752,7 @@ abstract class O3PO_PublicationType {
 
             echo '<h4>Validation results</h4>';
             echo '<div style="width:100%; background-color: #fff; border: 1px solid #eee"><div style="margin:6pt 6pt 6pt 6pt">';
-            foreach(preg_split("/\n/", $validation_result) as $line){
+            foreach(preg_split("/\n/", $validation_result, -1, PREG_SPLIT_NO_EMPTY) as $line){
                 $color = "green";
                 if(strpos($line, 'WARNING') !== false)
                     $color = "orange";

--- a/o3po/includes/class-o3po-secondary-publication-type.php
+++ b/o3po/includes/class-o3po-secondary-publication-type.php
@@ -277,7 +277,7 @@ class O3PO_SecondaryPublicationType extends O3PO_PublicationType {
                         $validation_result .= "WARNING: Affiliations of reviewer " . ($x+1) . " are empty.\n" ;
                     else {
                         $last_affiliation_num = 0;
-                        foreach(preg_split('/,/', $reviewer_affiliations[$x]) as $affiliation_num) {
+                        foreach(preg_split('/\s*,\s*/', $reviewer_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY) as $affiliation_num) {
                             if ($affiliation_num < 1 or $affiliation_num > $number_reviewer_institutions )
                                 $validation_result .= "ERROR: At least one affiliation number of reviewer " . ($x+1) . " does not correspond to an actual affiliation.\n" ;
                             if( $last_affiliation_num >= $number_reviewer_institutions )
@@ -859,7 +859,7 @@ class O3PO_SecondaryPublicationType extends O3PO_PublicationType {
                 if( !$all_authors_have_same_affiliation && !empty($author_affiliations) && !empty($author_affiliations[$x]) )
                 {
                     $content .= ' (';
-                    $this_authors_affiliations = preg_split('/,/', $author_affiliations[$x]);
+                    $this_authors_affiliations = preg_split('/\s*,\s*/', $author_affiliations[$x], -1, PREG_SPLIT_NO_EMPTY);
                     $this_authors_affiliations_count = count($this_authors_affiliations);
                     foreach($this_authors_affiliations as $y => $affiliation_num)
                     {
@@ -875,7 +875,7 @@ class O3PO_SecondaryPublicationType extends O3PO_PublicationType {
                 if( $x === $number_authors-2 ) $content .= "and ";
             }
             if(!empty($affiliations) && !empty(end($affiliations)) && $all_authors_have_same_affiliation && !empty($author_affiliations) ) {
-                $this_authors_affiliations = preg_split('/,/', $author_affiliations[0], 0, PREG_SPLIT_NO_EMPTY);
+                $this_authors_affiliations = preg_split('/\s*,\s*/', $author_affiliations[0], -1, PREG_SPLIT_NO_EMPTY);
                 $this_authors_affiliations_count = count($this_authors_affiliations);
                 if($this_authors_affiliations_count > 0)
                 {

--- a/tests/resources/kses.php
+++ b/tests/resources/kses.php
@@ -549,7 +549,7 @@ function wp_kses_one_attr( $string, $element ) {
 	$allowed_html = wp_kses_allowed_html( 'post' );
 	$allowed_protocols = wp_allowed_protocols();
 	$string = wp_kses_no_null( $string, array( 'slash_zero' => 'keep' ) );
-	
+
 	// Preserve leading and trailing whitespace.
 	$matches = array();
 	preg_match('/^\s*/', $string, $matches);
@@ -561,9 +561,9 @@ function wp_kses_one_attr( $string, $element ) {
 	} else {
 		$string = substr( $string, strlen( $lead ), -strlen( $trail ) );
 	}
-	
+
 	// Parse attribute name and value from input.
-	$split = preg_split( '/\s*=\s*/', $string, 2 );
+	$split = preg_split( '/\s*=\s*/', $string, 2, PREG_SPLIT_NO_EMPTY);
 	$name = $split[0];
 	if ( count( $split ) == 2 ) {
 		$value = $split[1];
@@ -598,7 +598,7 @@ function wp_kses_one_attr( $string, $element ) {
 		$value = '';
 		$vless = 'y';
 	}
-	
+
 	// Sanitize attribute by name.
 	wp_kses_attr_check( $name, $value, $string, $vless, $element, $allowed_html );
 
@@ -1062,7 +1062,7 @@ function wp_kses_attr_parse( $element ) {
 	} else {
 		$xhtml_slash = '';
 	}
-	
+
 	// Split it
 	$attrarr = wp_kses_hair_parse( $attr );
 	if ( false === $attrarr ) {
@@ -1072,7 +1072,7 @@ function wp_kses_attr_parse( $element ) {
 	// Make sure all input is returned by adding front and back matter.
 	array_unshift( $attrarr, $begin . $slash . $elname );
 	array_push( $attrarr, $xhtml_slash . $end );
-	
+
 	return $attrarr;
 }
 
@@ -1322,7 +1322,7 @@ function wp_kses_html_error($string) {
  * @return string Sanitized content
  */
 function wp_kses_bad_protocol_once($string, $allowed_protocols, $count = 1 ) {
-	$string2 = preg_split( '/:|&#0*58;|&#x0*3a;/i', $string, 2 );
+	$string2 = preg_split( '/:|&#0*58;|&#x0*3a;/i', $string, 2, PREG_SPLIT_NO_EMPTY);
 	if ( isset($string2[1]) && ! preg_match('%/\?%', $string2[0]) ) {
 		$string = trim( $string2[1] );
 		$protocol = wp_kses_bad_protocol_once2( $string2[0], $allowed_protocols );


### PR DESCRIPTION
Adds the PREG_SPLIT_NO_EMPTY flag to all calls of preg_split, where this is appropriate